### PR TITLE
return raw values without quotes

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -82,6 +82,8 @@ func fetchItem(url string, bearer string, item string, attachment string) (strin
 		return "", err
 	}
 
+	resp = resp[1 : len(resp)-1]
+
 	return resp, err
 }
 


### PR DESCRIPTION
causes this to return only the credential with no quotes.  removes extra step of stripping quotes off for downstream jobs/etc which use this